### PR TITLE
Fix undefined reference to CORTEXM_SVCALL_ENTER macro

### DIFF
--- a/src/sys/unistd/uidgid.c
+++ b/src/sys/unistd/uidgid.c
@@ -23,6 +23,7 @@
 
 #include "sos/sos.h"
 #include "cortexm/task.h"
+#include "cortexm/cortexm.h"
 #include "mcu/mcu.h"
 #include "../scheduler/scheduler_flags.h"
 


### PR DESCRIPTION
 from src/sys/unistd/uidgid.c by directly including the header that it's defined in