### PR TITLE
Update for no warnings with GCC11

### DIFF
--- a/arm.cmake
+++ b/arm.cmake
@@ -458,7 +458,7 @@ if(BUILD_BOOT OR BUILD_ALL)
   target_sources(${BOOT_RELEASE_TARGET} PRIVATE ${BOOT_SOURCELIST})
   target_include_directories(${BOOT_RELEASE_TARGET} PRIVATE ${SYS_INCLUDE_DIRECTORIES})
   target_compile_definitions(${BOOT_RELEASE_TARGET} PRIVATE ${COMPILE_DEFINITIONS_PRIVATE})
-  target_compile_options(${BOOT_RELEASE_TARGET} PUBLIC -Os)
+  target_compile_options(${BOOT_RELEASE_TARGET} PUBLIC -Os PRIVATE -Wno-address-of-packed-member)
 
   cmsdk2_copy_target(
     SOURCE ${BOOT_RELEASE_TARGET}
@@ -475,5 +475,3 @@ endif()
 install(DIRECTORY include/cortexm include/device include/mcu include/sos include/usbd DESTINATION include PATTERN CMakelists.txt EXCLUDE)
 install(DIRECTORY include/posix/ DESTINATION include PATTERN CMakelists.txt EXCLUDE)
 install(DIRECTORY ldscript/ DESTINATION lib/ldscripts PATTERN CMakelists.txt EXCLUDE)
-
-#/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/local/bin/arm-none-eabi-gcc -DCMSDK_BUILD_GIT_HASH=225c186 -D__PROJECT_VERSION_MAJOR=4 -D__PROJECT_VERSION_MINOR=2 -D__PROJECT_VERSION_PATCH=0 -D___debug -D__v7em_f4sh -I/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/dependencies/StratifyOS/src -I/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/dependencies/StratifyOS/include -I/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/dependencies/StratifyOS/include/posix -I/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/config -I/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/dependencies/InetAPI/lwip/include -I/Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/dependencies/InetAPI/lwip/lwip-2.1.2/src/include -Os -mthumb -ffunction-sections -fdata-sections -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16 -U__SOFTFP__ -D__FPU_PRESENT=1 -DARM_MATH_CM4=1 -MD -MT SDK/StratifyOS/CMakeFiles/StratifyOS_cortexm_debug_v7em_f4sh.dir/src/cortexm/devfs.c.obj -MF SDK/StratifyOS/CMakeFiles/StratifyOS_cortexm_debug_v7em_f4sh.dir/src/cortexm/devfs.c.obj.d -o SDK/StratifyOS/CMakeFiles/StratifyOS_cortexm_debug_v7em_f4sh.dir/src/cortexm/devfs.c.obj -c /Users/tgil/gitv4/StratifyOS-Nucleo144/SDK/dependencies/StratifyOS/src/cortexm/devfs.c

--- a/include/sos/dev/drive.h
+++ b/include/sos/dev/drive.h
@@ -35,7 +35,7 @@
 #define DRIVE_VERSION (0x030000)
 #define DRIVE_IOC_IDENT_CHAR 'd'
 
-enum {
+typedef enum {
 	DRIVE_FLAG_PROTECT /*! Enables driver write protection. */ = (1<<0),
 	DRIVE_FLAG_UNPROTECT /*! Disables driver write protection. */ = (1<<1),
 	DRIVE_FLAG_ERASE_BLOCKS /*! Erases blocks on the disk. A block consists of the smallest eraseable memory size (\sa driver_info_t and erase_block_size). The return value is the amount of memory actually erased. Some devices can only erase only block at a time. */ = (1<<2),

--- a/src/boot/boot_link.c
+++ b/src/boot/boot_link.c
@@ -160,7 +160,7 @@ void boot_link_cmd_readserialno(link_transport_driver_t *driver, link_data_t *ar
     }
   }
 
-  args->reply.err = strnlen(serialno, 256);
+  args->reply.err = strnlen(serialno, LINK_PACKET_DATA_SIZE-1);
   args->reply.err_number = 0;
 
   if (


### PR DESCRIPTION
Minor fixes to fix GCC11 warnings.

Needs to cherry-pick to main.